### PR TITLE
Add support for lodash 4.x (Found in Grunt 1.x)

### DIFF
--- a/main.js
+++ b/main.js
@@ -14,7 +14,7 @@ module.exports = function(grunt) {
 	return function (options) {
 		var me = this;
 
-		_.each(_.rest(arguments), function (key) {
+		_.each(_.tail(arguments), function (key) {
 			var value = me[key];
 
 			if (grunt.util.kindOf(value) === "string") {


### PR DESCRIPTION
- Changed lodash `rest` usage to tail.
  - Note this still supports lodash 3.x as tail was an alias for the original rest.  Both 3.x and 4.x tail do the same thing.
